### PR TITLE
use 'lighter' global composite operation

### DIFF
--- a/lib/activate-power-mode.coffee
+++ b/lib/activate-power-mode.coffee
@@ -98,7 +98,9 @@ module.exports = ActivatePowerMode =
 
   drawParticles: ->
     requestAnimationFrame @drawParticles.bind(this)
+    gco = @context.globalCompositeOperation
     @context.clearRect 0, 0, @canvas.width, @canvas.height
+    @context.globalCompositeOperation = "lighter"
 
     for particle in @particles
       continue if particle.alpha <= 0.1
@@ -114,6 +116,7 @@ module.exports = ActivatePowerMode =
         Math.round(particle.y - 1.5)
         3, 3
       )
+    @context.globalCompositeOperation = gco
 
   toggle: ->
     console.log 'ActivatePowerMode was toggled!'


### PR DESCRIPTION
The "lighter" global composite operation looks the most rad when it comes to particle effects ([source](http://www.mrspeaker.net/dev/parcycle/)).

![screen shot 2015-12-02 at 6 22 16 pm](https://cloud.githubusercontent.com/assets/129330/11547475/30780834-9922-11e5-861e-55f04d6e9bfe.png)
 