### PR TITLE
Add excluded file types feature in settings

### DIFF
--- a/lib/activate-power-mode.coffee
+++ b/lib/activate-power-mode.coffee
@@ -33,6 +33,7 @@ module.exports = ActivatePowerMode =
 
     @editor = atom.workspace.getActiveTextEditor()
     return unless @editor
+    return if @editor.getGrammar().name.toLowerCase() in @getConfig "excludedFileTypes.excluded"
 
     @editorElement = atom.views.getView @editor
     @editorElement.classList.add "power-mode"

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -74,3 +74,11 @@ module.exports =
             type: "integer"
             default: 4
             minimum: 0
+  excludedFileTypes:
+    type: "object"
+    properties:
+      excluded:
+        title: "Prohibit activate-power-mode from enabling on these file types:"
+        description: "Use comma separated, lowercase values (i.e. \"html, cpp, css\")"
+        type: "array"
+        default: ["."]


### PR DESCRIPTION
The HEAD is currently buggy in certain file types (html specifically). This update adds a setting to specify file types to exclude as lowercase, comma separated values (i.e. "html, cpp, css").

This allows a user to exclude HTML files, toggle activate-power-mode on, and switch freely between HTML and JavaScript, with activate-power-mode only functioning in the non-HTML files.

This, more importantly, could be used to force activate-power-mode to work in only scripting languages, without having to manually toggle the plugin when switching editor views.