### PR TITLE
Fix when open a new atom window

### DIFF
--- a/lib/activate-power-mode.coffee
+++ b/lib/activate-power-mode.coffee
@@ -15,10 +15,8 @@ module.exports = ActivatePowerMode =
     @subscriptions.add atom.commands.add "atom-workspace",
       "activate-power-mode:toggle": => @toggle()
 
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+    @activeItemSubscription = atom.workspace.onDidStopChangingActivePaneItem =>
       @subscribeToActiveTextEditor()
-
-    @subscribeToActiveTextEditor()
 
     if @getConfig "autoToggle"
       @toggle()


### PR DESCRIPTION
It seems even when the editor is created its view sometimes is not yet ready to be used. So changing the event fixes this.