### PR TITLE
add class when combo is 0

### DIFF
--- a/lib/combo-mode.coffee
+++ b/lib/combo-mode.coffee
@@ -31,6 +31,7 @@ module.exports =
     if not @container
       @maxStreak = @getMaxStreak()
       @container = @createElement "streak-container"
+      @container.classList.add "combo-zero"
       @title = @createElement "title", @container
       @title.textContent = "Combo"
       @max = @createElement "max", @container
@@ -66,6 +67,7 @@ module.exports =
 
     @currentStreak++
 
+    @container.classList.remove "combo-zero"
     if @currentStreak > @maxStreak
       @increaseMaxStreak()
 
@@ -83,6 +85,7 @@ module.exports =
     @currentStreak = 0
     @reached = false
     @maxStreakReached = false
+    @container.classList.add "combo-zero"
     @container.classList.remove "reached"
     @renderStreak()
 


### PR DESCRIPTION
Adds a `combo-zero` class on the combo container when combo is 0.

This adds the possibility to do what is described in the #239 with the following pasted on your styles.less:
```css
atom-text-editor .streak-container.combo-zero {
  display: none;
}
```