### PR TITLE
Destruction mode

### DIFF
--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -37,8 +37,7 @@ module.exports =
 
       exclamationEvery:
         title: "Combo Mode - Exclamation Every"
-        description: "Shows an exclamation every streak      console.log e
- count."
+        description: "Shows an exclamation every streak count."
         type: "integer"
         default: 10
         minimum: 1

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -37,7 +37,8 @@ module.exports =
 
       exclamationEvery:
         title: "Combo Mode - Exclamation Every"
-        description: "Shows an exclamation every streak count."
+        description: "Shows an exclamation every streak      console.log e
+ count."
         type: "integer"
         default: 10
         minimum: 1
@@ -224,3 +225,10 @@ module.exports =
     type: "object"
     order: 8
     properties: {}
+
+  justDeletes:
+    title: "Destruction mode"
+    order: 1
+    type: "boolean"
+    description: "Only listen to deletes"
+    default: false

--- a/lib/power-editor.coffee
+++ b/lib/power-editor.coffee
@@ -51,6 +51,10 @@ module.exports =
       cursor = @editor.getCursorAtScreenPosition screenPos
       return unless cursor
 
+      if @getConfig "justDeletes"
+        unless @inputHandler.hasDeleted()
+          return
+
       @pluginManager.runOnInput cursor, screenPos, @inputHandler
 
   getConfig: (config) ->


### PR DESCRIPTION
This adds a setting to have powermode only listen to deletes, I use this personally to save cpu resources but still see the effect occasionally. And it kinda acts like the characters are exploding when you delete them. Super simple changes but useful. I know someone else forked the package to do this but it is way out of date and I thought it made more sense as a setting.