### PR TITLE
getCurrentStreak() Added.

### DIFF
--- a/lib/combo-renderer.coffee
+++ b/lib/combo-renderer.coffee
@@ -91,6 +91,7 @@ module.exports =
   resetCounter: ->
     return if @currentStreak is 0
 
+
     @showExclamation "#{-@currentStreak}", 'down', false
     @endStreak()
 
@@ -154,6 +155,9 @@ module.exports =
   getLevel: ->
     @level
 
+  getCurrentStreak: ->
+    @currentStreak
+    
   endStreak: ->
     @currentStreak = 0
     @maxStreakReached = false

--- a/lib/service/combo-api.coffee
+++ b/lib/service/combo-api.coffee
@@ -1,3 +1,4 @@
+
 module.exports = class ComboApi
   constructor: (comboRenderer) ->
     @combo = comboRenderer
@@ -20,5 +21,11 @@ module.exports = class ComboApi
     else
       null
 
+  getCurrentStreak: ->
+    if @combo.isEnable
+      @combo.getCurrentStreak()
+    else
+      null
+      
   isEnable: ->
     @combo.isEnable


### PR DESCRIPTION
To get current streak on the Combo-API.
To solve issue #287.