### PR TITLE
Fix Activation Threshold setting not rendering

### DIFF
--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -19,13 +19,13 @@ module.exports =
 
       activationThreshold:
         title: "Combo Mode - Activation Threshold"
-        description: "Streak threshold to activate the power mode."
+        description: "Streak threshold to activate the power mode and levels."
         type: "array"
-        default: [20, 50, 100, 200, 500]
-        items:
-          type: "integer"
-          minimum: 1
-          maximum: 1000
+        default: ['20', '50', '100', '200', '500']
+        # items:
+        #   type: "integer"
+        #   minimum: 1
+        #   maximum: 1000
 
       streakTimeout:
         title: "Combo Mode - Streak Timeout"


### PR DESCRIPTION
Fix the `Activation Threshold` setting not displaying in the atom settings pane.
Seems there is an issue displaying an array type with integers items.
