### PR TITLE
Add exclamation modifier data to combo switcher

### DIFF
--- a/lib/plugin/combo-mode.coffee
+++ b/lib/plugin/combo-mode.coffee
@@ -22,4 +22,7 @@ module.exports =
     if data['qty']
       qty = data['qty']
 
+    if data['exclamation']
+      @combo.showExclamation data['exclamation'], data['exclamation_type']
+
     @combo.modifyStreak qty


### PR DESCRIPTION
Added exclamation modifier data for custom flows, an example:
```coffeescript
switcher.on('comboMode', {'exclamation': 'NEW LINE', 'exclamation_type': 'error'})
```
Fixes #283 
