### PR TITLE
Use transform: translate() on shake effect

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -6,7 +6,7 @@ module.exports = class Api
     @combo = comboApi
 
   shakeScreen: (intensity = null) ->
-    @screenShaker.shake @editorRegistry.getEditorElement(), intensity
+    @screenShaker.shake @editorRegistry.getScrollView(), intensity
 
   playAudio: (audio) ->
     @audioPlayer.play(audio)

--- a/lib/plugin-manager.coffee
+++ b/lib/plugin-manager.coffee
@@ -82,7 +82,6 @@ module.exports =
 
   runOnChangePane: (editor = null, editorElement = null) ->
     @editorRegistry.setEditor editor
-    @editorRegistry.setEditorElement editorElement
 
     @pluginRegistry.onEnabled(
       (code, plugin) -> plugin.onChangePane?(editor, editorElement)

--- a/lib/service/editor-registry.coffee
+++ b/lib/service/editor-registry.coffee
@@ -5,8 +5,10 @@ module.exports =
   getEditorElement: ->
     @editorElement
 
+  getScrollView: ->
+    @scrollView
+
   setEditor: (editor) ->
     @editor = editor
-
-  setEditorElement: (editorElement) ->
-    @editorElement = editorElement
+    @editorElement = editor.getElement()
+    @scrollView = @editorElement.querySelector(".scroll-view")

--- a/lib/service/editor-registry.coffee
+++ b/lib/service/editor-registry.coffee
@@ -9,6 +9,9 @@ module.exports =
     @scrollView
 
   setEditor: (editor) ->
-    @editor = editor
-    @editorElement = editor.getElement()
-    @scrollView = @editorElement.querySelector(".scroll-view")
+    if editor
+      @editor = editor
+      @editorElement = editor.getElement()
+      @scrollView = @editorElement.querySelector(".scroll-view")
+    else
+      @editor = @editorElement = @scrollView = null

--- a/lib/service/screen-shaker.coffee
+++ b/lib/service/screen-shaker.coffee
@@ -54,12 +54,10 @@ module.exports =
     x = @shakeIntensity min, max
     y = @shakeIntensity min, max
 
-    element.style.top = "#{y}px"
-    element.style.left = "#{x}px"
+    element.style.transform = "translate(#{x}px, #{y}px)"
 
     setTimeout ->
-      element.style.top = ""
-      element.style.left = ""
+      element.style.transform = ""
     , 75
 
   shakeIntensity: (min, max) ->

--- a/styles/activate-power-mode.less
+++ b/styles/activate-power-mode.less
@@ -19,8 +19,8 @@
   pointer-events: none;
 }
 
-atom-text-editor {
-  will-change: top, left;
+atom-text-editor .scroll-view {
+  will-change: transform;
 }
 
 .streak-container {


### PR DESCRIPTION
Addressing comments in #203 
Seems to be better to use `transform: translate()` than `left` & `top`.