### PR TITLE
Plugin activate/deactivate detection and performance update.

### DIFF
--- a/lib/combo-renderer.coffee
+++ b/lib/combo-renderer.coffee
@@ -129,9 +129,9 @@ module.exports =
     if @conf['exclamationEvery'] > 0
       mod = @currentStreak % @conf['exclamationEvery']
       if mod is 0 or (@currentStreak - n < @currentStreak - mod < @currentStreak)
-        @showExclamation()
-    else
-      @showExclamation "+#{n}", 'up', false
+        return @showExclamation()
+
+    @showExclamation "+#{n}", 'up', false
 
   streakDecreased: (n) ->
     @showExclamation "#{n}", 'down', false

--- a/lib/combo-renderer.coffee
+++ b/lib/combo-renderer.coffee
@@ -126,9 +126,10 @@ module.exports =
 
     return if @checkLevel()
 
-    mod = @currentStreak % @conf['exclamationEvery']
-    if mod is 0 or (@currentStreak - n < @currentStreak - mod < @currentStreak)
-      @showExclamation()
+    if @conf['exclamationEvery'] > 0
+      mod = @currentStreak % @conf['exclamationEvery']
+      if mod is 0 or (@currentStreak - n < @currentStreak - mod < @currentStreak)
+        @showExclamation()
     else
       @showExclamation "+#{n}", 'up', false
 

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -44,10 +44,10 @@ module.exports =
 
       exclamationEvery:
         title: "Combo Mode - Exclamation Every"
-        description: "Shows an exclamation every streak count."
+        description: "Shows an exclamation every streak count. (Let in 0 to disable)"
         type: "integer"
         default: 10
-        minimum: 1
+        minimum: 0
         maximum: 100
 
       exclamationTexts:

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -52,9 +52,6 @@ module.exports =
   observePlugin: (code, plugin, key) ->
     @subscriptions.add atom.config.observe(
       key, (isEnabled) =>
-        if plugin.name? and atom.packages.isPackageDisabled(plugin.name) and isEnabled
-            return atom.config.set(key, false)
-
         if isEnabled
           plugin.enable?(@api)
           @enabledPlugins[code] = plugin

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -6,7 +6,6 @@ module.exports =
   plugins: []
   corePlugins: []
   enabledPlugins: []
-  registedPlugins: []
 
   init: (configSchema, api) ->
     @config = configSchema
@@ -22,10 +21,7 @@ module.exports =
 
     for code, plugin of @plugins
       key = "activate-power-mode.plugins.#{code}"
-      continue if plugin.name? and plugin.name is @registedPlugins[code]
-      @registedPlugins[code] = plugin.name if plugin.name?
-
-      @addConfigForPlugin(code, plugin, key) if atom.config.get(key) == undefined
+      @addConfigForPlugin(code, plugin, key)
       @observePlugin code, plugin, key
 
   disable: ->
@@ -40,12 +36,11 @@ module.exports =
     @plugins[code] = plugin
 
     if @enabled
-      return null if plugin.name? and @registedPlugins[code] is plugin.name
-      @registedPlugins[code] = plugin.name if plugin.name?
-      @addConfigForPlugin(code, plugin, key) if atom.config.get(key) == undefined
+      @addConfigForPlugin(code, plugin, key)
       @observePlugin code, plugin, key
 
   addConfigForPlugin: (code, plugin, key) ->
+    return if atom.config.get(key) == undefined
     @config.plugins.properties[code] =
       type: 'boolean',
       title: plugin.title,

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -12,7 +12,6 @@ module.exports =
     @api = api
 
   enable: ->
-    @count = 0
     @subscriptions = new CompositeDisposable
     @enabled = true
 
@@ -40,14 +39,14 @@ module.exports =
       @observePlugin code, plugin, key
 
   addConfigForPlugin: (code, plugin, key) ->
-    return if atom.config.get(key) != undefined
     @config.plugins.properties[code] =
       type: 'boolean',
       title: plugin.title,
       description: plugin.description,
       default: true
 
-    atom.config.set key, @config.plugins.properties[code].default
+    if atom.config.get(key) is undefined
+      atom.config.set key, @config.plugins.properties[code].default
 
   observePlugin: (code, plugin, key) ->
     @subscriptions.add atom.config.observe(

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -75,9 +75,9 @@ module.exports =
     @subscriptions.add atom.config.observe(
       key, (isEnabled) =>
         console.log "El plugin observer " + plugin.name + "se ha invocado " + ++@count
-        if plugin.name? and atom.packages.isPackageDisabled(plugin.name)
+        if plugin.name? and atom.packages.isPackageDisabled(plugin.name) and isEnabled
             console.error "Yo me invoque jejeje XD"
-            return atom.config.set(key, false) if isEnabled
+            return atom.config.set(key, false)
 
         if isEnabled
           plugin.enable?(@api)

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -25,7 +25,7 @@ module.exports =
       continue if plugin.name? and plugin.name is @registedPlugins[code]
       @registedPlugins[code] = plugin.name if plugin.name?
 
-      @addConfigForPlugin code, plugin, key
+      @addConfigForPlugin(code, plugin, key) if atom.config.get(key) == undefined
       @observePlugin code, plugin, key
 
   disable: ->
@@ -42,7 +42,7 @@ module.exports =
     if @enabled
       return null if plugin.name? and @registedPlugins[code] is plugin.name
       @registedPlugins[code] = plugin.name if plugin.name?
-      @addConfigForPlugin code, plugin, key
+      @addConfigForPlugin(code, plugin, key) if atom.config.get(key) == undefined
       @observePlugin code, plugin, key
 
   addConfigForPlugin: (code, plugin, key) ->
@@ -52,8 +52,7 @@ module.exports =
       description: plugin.description,
       default: true
 
-    if atom.config.get(key) == undefined
-      atom.config.set key, @config.plugins.properties[code].default
+    atom.config.set key, @config.plugins.properties[code].default
 
   observePlugin: (code, plugin, key) ->
     @subscriptions.add atom.config.observe(

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -40,7 +40,7 @@ module.exports =
       @observePlugin code, plugin, key
 
   addConfigForPlugin: (code, plugin, key) ->
-    return if atom.config.get(key) == undefined
+    return if atom.config.get(key) != undefined
     @config.plugins.properties[code] =
       type: 'boolean',
       title: plugin.title,

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -6,12 +6,14 @@ module.exports =
   plugins: []
   corePlugins: []
   enabledPlugins: []
+  registedPlugins: []
 
   init: (configSchema, api) ->
     @config = configSchema
     @api = api
 
   enable: ->
+    @count = 0
     @subscriptions = new CompositeDisposable
     @enabled = true
 
@@ -20,8 +22,16 @@ module.exports =
 
     for code, plugin of @plugins
       key = "activate-power-mode.plugins.#{code}"
+      isPackage = if plugin.name? then true else false
+      continue if isPackage and @registedPlugins[code] is plugin.name
+      @registedPlugins[code] = plugin.name if isPackage
       @addConfigForPlugin code, plugin, key
+      if isPackage
+        @observePackagePlugin code, plugin, key
+        continue
       @observePlugin code, plugin, key
+
+    @observePackage() if @plugins != null
 
   disable: ->
     @enabled = false
@@ -35,8 +45,10 @@ module.exports =
     @plugins[code] = plugin
 
     if @enabled
+      return null if plugin.name? and @registedPlugins[code] is plugin.name
+      @registedPlugins[code] = plugin.name if plugin.name?
       @addConfigForPlugin code, plugin, key
-      @observePlugin code, plugin, key
+      @observePackagePlugin code, plugin, key
 
   addConfigForPlugin: (code, plugin, key) ->
     @config.plugins.properties[code] =
@@ -59,6 +71,36 @@ module.exports =
           delete @enabledPlugins[code]
     )
 
+  observePackagePlugin: (code, plugin, key) ->
+    @subscriptions.add atom.config.observe(
+      key, (isEnabled) =>
+        console.log "El plugin observer " + plugin.name + "se ha invocado " + ++@count
+        if plugin.name? and atom.packages.isPackageDisabled(plugin.name)
+            console.error "Yo me invoque jejeje XD"
+            return atom.config.set(key, false) if isEnabled
+
+        if isEnabled
+          plugin.enable?(@api)
+          @enabledPlugins[code] = plugin
+        else
+          plugin.disable?()
+          delete @enabledPlugins[code]
+    )
+
+  observePackage: ->
+    @subscriptions.add atom.packages.onDidActivatePackage (packages) =>
+      for code, name of @registedPlugins
+        if name is packages.name
+          atom.config.set("activate-power-mode.plugins.#{code}", true) if !@isActive(code)
+
+    @subscriptions.add atom.packages.onDidDeactivatePackage (packages) =>
+      for code, name of @registedPlugins
+        if name is packages.name
+          atom.config.set("activate-power-mode.plugins.#{code}", false) if @isActive(code)
+
   onEnabled: (callback) ->
     for code, plugin of @enabledPlugins
       continue if callback code, plugin
+
+  isActive: (code) ->
+    atom.config.get "activate-power-mode.plugins.#{code}"

--- a/lib/plugin-registry.coffee
+++ b/lib/plugin-registry.coffee
@@ -66,6 +66,3 @@ module.exports =
   onEnabled: (callback) ->
     for code, plugin of @enabledPlugins
       continue if callback code, plugin
-
-  isActive: (code) ->
-    atom.config.get "activate-power-mode.plugins.#{code}"


### PR DESCRIPTION
I solve another issue related with the package activation/deactivation. When the package gets deactivated by the user, the package: (`activate-power-mode`) keeps calling the plugin. And also the plugin can be reactivated after the package deactivation. 

So that I include this 33d89d1f7b8c70f58709aa4260e8149a44a9914a on the config observer for the plugin.
```coffee
if plugin.name? and atom.packages.isPackageDisabled(plugin.name) and isEnabled
  return atom.config.set(key, false)
```
It require the attribute `name` inside of the plugin which contains the package name, to determinate if package is active or not.

```coffee
  title: 'Activate Killer Instinct Mode'
  description: 'A plugin for activate power mode that plays killer instinct exclamations.'
  name: "activate-killer-instinct-mode"
  type: "package"
```

This addition prevent plugin activation if the package is deactivated.
You can watch the main file for my [package](https://github.com/Jerajo/activate-killer-instinct-mode/blob/master/lib/activate-killer-instinct-mode.coffee) and look what I used to disable plugin.