### PR TITLE
Let "Exclamation Every" in 0 to disable.

### DIFF
--- a/lib/combo-renderer.coffee
+++ b/lib/combo-renderer.coffee
@@ -126,11 +126,12 @@ module.exports =
 
     return if @checkLevel()
 
-    mod = @currentStreak % @conf['exclamationEvery']
-    if mod is 0 or (@currentStreak - n < @currentStreak - mod < @currentStreak)
-      @showExclamation()
-    else
-      @showExclamation "+#{n}", 'up', false
+    if @conf['exclamationEvery'] > 0
+      mod = @currentStreak % @conf['exclamationEvery']
+      if mod is 0 or (@currentStreak - n < @currentStreak - mod < @currentStreak)
+        return @showExclamation()
+
+    @showExclamation "+#{n}", 'up', false
 
   streakDecreased: (n) ->
     @showExclamation "#{n}", 'down', false

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -44,10 +44,10 @@ module.exports =
 
       exclamationEvery:
         title: "Combo Mode - Exclamation Every"
-        description: "Shows an exclamation every streak count."
+        description: "Shows an exclamation every streak count. (Let in 0 to disable)"
         type: "integer"
         default: 10
-        minimum: 1
+        minimum: 0
         maximum: 100
 
       exclamationTexts:


### PR DESCRIPTION
I added the capacity to disable the exclamations, on `comboMode.exclamationEvery` **(Let in 0 to disable).**
To prevent double exclamations on `api ` > `combo` > `exclame` and using the event `onComboExclamation()`

**For example:**
```coffee
onComboExclamation: (text) ->
    @combo.exclame("Maximum Combo!")
```
or
```coffee
onInput: (cursor, screenPosition, input, data) ->
    @combo = @api.combo()
    if @checkExclamation() #returns true when exclamation every is fulfilled.
        @combo.exclame("Maximum Combo!")
```
![error](https://user-images.githubusercontent.com/26252994/30217955-b663736a-9485-11e7-8036-dc8b29aaf040.gif)