### PR TITLE
Add random per spawn color option.

### DIFF
--- a/lib/color-helper.coffee
+++ b/lib/color-helper.coffee
@@ -43,17 +43,29 @@ module.exports =
       yield color
     return
 
+  getRandomColor: (seed) ->
+    seed = Math.random()
+    seed += @golden_ratio_conjugate
+    seed = seed - (seed//1)
+    rgb = @hsvToRgb(seed,1,1)
+    r = (rgb[0]*255)//1
+    g = (rgb[1]*255)//1
+    b = (rgb[2]*255)//1
+    "rgb(#{r},#{g},#{b})"
+
   getRandomGenerator: ->
     seed = Math.random()
-    loop
-      seed += @golden_ratio_conjugate
-      seed = seed - (seed//1)
-      rgb = @hsvToRgb(seed,1,1)
-      r = (rgb[0]*255)//1
-      g = (rgb[1]*255)//1
-      b = (rgb[2]*255)//1
 
-      yield "rgb(#{r},#{g},#{b})"
+    loop
+      yield @getRandomColor seed
+    return
+
+  getRandomSpawnGenerator: ->
+    seed = Math.random()
+    color = @getRandomColor seed
+
+    loop
+      yield color
     return
 
   getColorAtCursorGenerator: (cursor, editorElement) ->
@@ -82,5 +94,7 @@ module.exports =
       return @getRandomGenerator()
     else if colorType == 'fixed'
       @getFixedColorGenerator()
+    else if colorType == 'randomSpawn'
+      @getRandomSpawnGenerator()
     else
       @getColorAtCursorGenerator cursor, editorElement

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -84,9 +84,10 @@ module.exports =
             type: "string"
             default: "cursor"
             enum: [
-              {value: 'cursor', description: 'Particles will be the colour at the cursor.'}
-              {value: 'random', description: 'Particles will have random colours.'}
-              {value: 'fixed', description: 'Particles will have a fixed colour.'}
+              {value: 'cursor', description: 'Colour at the cursor.'}
+              {value: 'randomSpawn', description: 'Random colour per spawn.'}
+              {value: 'random', description: 'Random colours per particle.'}
+              {value: 'fixed', description: 'Fixed colour.'}
             ]
             order: 1
 


### PR DESCRIPTION
This adds a new color option: Random per spawn of particles.
Also changes a bit the options descriptions.

The new option in comparison with the random per particle option:
![1504945426284](https://user-images.githubusercontent.com/10590799/30238549-c88dcc96-950e-11e7-9ca5-fea396bfcfaa.gif)
![1504945468122](https://user-images.githubusercontent.com/10590799/30238551-cb24827e-950e-11e7-880e-62e2b82b8f94.gif)
