### PR TITLE
Add unregister* methods in service api.

### DIFF
--- a/lib/effect-registry.coffee
+++ b/lib/effect-registry.coffee
@@ -26,6 +26,14 @@ module.exports =
     if atom.config.get(@key) is code
       @effect = effect
 
+  removeEffect: (code) ->
+    if atom.config.get(@key) is code
+      @effect.disable()
+      @effect = @effects['default']
+      @effect.init()
+
+    delete @effects[code]
+
   observeEffect: ->
     @subscriptions.add atom.config.observe(
       @key, (code) =>

--- a/lib/flow-registry.coffee
+++ b/lib/flow-registry.coffee
@@ -26,6 +26,12 @@ module.exports =
     if atom.config.get(@key) is code
       @flow = flow
 
+  removeFlow: (code) ->
+    if atom.config.get(@key) is code
+      @flow = @flows['default']
+
+    delete @flows[code]
+
   observeFlow: ->
     @subscriptions.add atom.config.observe(
       @key, (code) =>

--- a/lib/service.coffee
+++ b/lib/service.coffee
@@ -15,5 +15,14 @@ module.exports = class Service
   registerEffect: (code, effect) ->
     @effectRegistry.addEffect code, effect
 
+  unregisterPlugin: (code) ->
+    @pluginRegistry.removePlugin code
+
+  unregisterFlow: (code) ->
+    @flowRegistry.removeFlow code
+
+  unregisterEffect: (code) ->
+    @effectRegistry.removeEffect code
+
   createParticlesEffect: (particleManager) ->
     new ParticlesEffect(particleManager)


### PR DESCRIPTION
This add the possibility to unregister flows, effects and plugins when a package is disabled or uninstalled. 

``` coffeescript
deactivate: ->
  @service.unregisterPlugin 'myPlugin'

consumeService: (service) ->
  @service = service
  service.registerPlugin 'myPlugin', plugin
```