### PR TITLE
Proof of concept for second audio for newline.

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -8,8 +8,8 @@ module.exports = class Api
   shakeScreen: (intensity = null) ->
     @screenShaker.shake @editorRegistry.getScrollView(), intensity
 
-  playAudio: (audio) ->
-    @audioPlayer.play(audio)
+  playAudio: (audio, input) ->
+    @audioPlayer.play(audio, input)
 
   getEditor: ->
     @editorRegistry.getEditor()

--- a/lib/plugin/play-audio.coffee
+++ b/lib/plugin/play-audio.coffee
@@ -8,5 +8,5 @@ module.exports =
     @api = api
     @throttledPlayAudio = throttle @api.playAudio.bind(@api), 100, trailing: false
 
-  onInput: ->
-    @throttledPlayAudio()
+  onInput: (cursor, screenPosition, input, data) ->
+    @throttledPlayAudio(null, input)

--- a/lib/service/audio-player.coffee
+++ b/lib/service/audio-player.coffee
@@ -46,10 +46,19 @@ module.exports =
       pathtoaudio = path.join("#{__dirname}/..", @conf['audioclip'])
     @audio = new Audio(pathtoaudio)
 
-  play: (audio) ->
+    pathtoaudio2 = pathtoaudio + "-enter";
+    @audio2 = new Audio(pathtoaudio2)
+
+  play: (audio, input) ->
     return if not @enabled
 
-    audio = @audio if not audio
+    if not audio
+      debugger
+      if input.isNewLine()
+        audio = @audio2;
+      else
+        audio = @audio;
+
     audio.currentTime = 0
     audio.volume = @conf['volume']
     audio.play()


### PR DESCRIPTION
Just a proof of concept for #323. If you dump an audio foo.wav-enter next to foo.wav, it will be used for newline characters.  Of course, there is a lot of extra configuration stuff missing around this.