### PR TITLE
Fix for Issue 277 (Cannot read property 'pixelPositionForScreenPosition' of null)

### DIFF
--- a/lib/canvas-renderer.coffee
+++ b/lib/canvas-renderer.coffee
@@ -86,6 +86,7 @@ module.exports =
     @observe 'size.max'
 
   spawn: (cursor, screenPosition, input, size) ->
+    return if not @editorElement
     position = @calculatePositions screenPosition
     colorGenerator = @colorHelper.generateColors cursor, @editorElement
     randomSize = => @randomSize(size)


### PR DESCRIPTION
Don't try to spawn a particle if the canvas has been destroyed and detached from editor