### PR TITLE
Error Thrown on Delete

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# activate-power-mode atom package
-A package for Atom to replicate the effects from [codeinthedark/editor](https://github.com/codeinthedark/editor). Available through the Atom package installer (https://atom.io/packages/activate-power-mode). 
+# activate-power-mode-delete atom package
+A package forked from [activate-power-mode](https://atom.io/packages/activate-power-mode). Original package was overwhelming, these effects are on delete only. Available through the Atom package installer (https://atom.io/packages/activate-power-mode-delete).
 
-Activate with <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>O</kbd> or through the command panel with `Activate Power Mode: Toggle`. Use the command again to deactivate. 
+Activate with <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>o</kbd> or through the command panel with `Activate Power Mode: Toggle`. Use the command again to deactivate.
 
 ![activate-power-mode-0 4 0](https://cloud.githubusercontent.com/assets/688415/11615565/10f16456-9c65-11e5-8af4-265f01fc83a0.gif)
-
-**For a list of power mode packages to other editors, check out [codeinthedark/awesome-power-mode](https://github.com/codeinthedark/awesome-power-mode).**

--- a/keymaps/activate-power-mode.cson
+++ b/keymaps/activate-power-mode.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
-  'ctrl-alt-o': 'activate-power-mode:toggle'
+  'ctrl-alt-o': 'activate-power-mode-delete:toggle'

--- a/lib/activate-power-mode.coffee
+++ b/lib/activate-power-mode.coffee
@@ -13,7 +13,7 @@ module.exports = ActivatePowerMode =
   activate: (state) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add "atom-workspace",
-      "activate-power-mode:toggle": => @toggle()
+      "activate-power-mode-delete:toggle": => @toggle()
 
     @activeItemSubscription = atom.workspace.onDidStopChangingActivePaneItem =>
       @subscribeToActiveTextEditor()
@@ -31,7 +31,7 @@ module.exports = ActivatePowerMode =
     @canvas = null
 
   getConfig: (config) ->
-    atom.config.get "activate-power-mode.#{config}"
+    atom.config.get "activate-power-mode-delete.#{config}"
 
   subscribeToActiveTextEditor: ->
     @throttledShake = throttle @shake.bind(this), 100, trailing: false
@@ -63,18 +63,19 @@ module.exports = ActivatePowerMode =
     left: scrollViewRect.left - editorRect.left
 
   onChange: (e) ->
-    return if not @active
-    spawnParticles = true
-    if e.newText
-      spawnParticles = e.newText isnt "\n"
-      range = e.newRange.end
-    else
-      range = e.newRange.start
+    if e.newText is ""
+      return if not @active
+      spawnParticles = true
+      if e.newText
+        spawnParticles = e.newText isnt "\n"
+        range = e.newRange.end
+      else
+        range = e.newRange.start
 
-    if spawnParticles and @getConfig "particles.enabled"
-      @throttledSpawnParticles range
-    if @getConfig "screenShake.enabled"
-      @throttledShake()
+      if spawnParticles and @getConfig "particles.enabled"
+        @throttledSpawnParticles range
+      if @getConfig "screenShake.enabled"
+        @throttledShake()
 
   shake: ->
     min = @getConfig "screenShake.minIntensity"

--- a/menus/activate-power-mode.cson
+++ b/menus/activate-power-mode.cson
@@ -2,19 +2,19 @@
 'context-menu':
   'atom-text-editor': [
     {
-      'label': 'Toggle activate-power-mode'
-      'command': 'activate-power-mode:toggle'
+      'label': 'Toggle activate-power-mode-delete'
+      'command': 'activate-power-mode-delete:toggle'
     }
   ]
 'menu': [
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'activate-power-mode'
+      'label': 'activate-power-mode-delete'
       'submenu': [
         {
           'label': 'Toggle'
-          'command': 'activate-power-mode:toggle'
+          'command': 'activate-power-mode-delete:toggle'
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "activate-power-mode-delete",
   "main": "./lib/activate-power-mode",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Activate POWER MODE to DELETE powerfully. Original package was overwhelming, these effects are on delete only.",
   "keywords": [],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
-  "name": "activate-power-mode",
+  "name": "activate-power-mode-delete",
   "main": "./lib/activate-power-mode",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Activate POWER MODE to write your code in style.",
   "keywords": [],
-  "repository": "https://github.com/JoelBesada/activate-power-mode",
-  "author": "Joel Besada <joel@joelb.me> (http://joelb.me)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/valmassoi/activate-power-mode-delete.git"
+  },
+  "author": {
+    "name": "Joel Besada",
+    "email": "joel@joelb.me",
+    "url": "http://joelb.me"
+  },
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
@@ -13,5 +20,87 @@
   "dependencies": {
     "lodash.random": "^3.0.1",
     "lodash.throttle": "^3.0.4"
+  },
+  "readme": "# activate-power-mode-delete atom package\nA package for Atom to replicate the effects from [codeinthedark/editor](https://github.com/codeinthedark/editor). Available through the Atom package installer (https://atom.io/packages/activate-power-mode-delete). \n\nActivate with <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>O</kbd> or through the command panel with `Activate Power Mode: Toggle`. Use the command again to deactivate. \n\n![activate-power-mode-delete-0 4 0](https://cloud.githubusercontent.com/assets/688415/11615565/10f16456-9c65-11e5-8af4-265f01fc83a0.gif)\n\n**For a list of power mode packages to other editors, check out [codeinthedark/awesome-power-mode](https://github.com/codeinthedark/awesome-power-mode).**\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": ""
+  },
+  "homepage": "",
+  "_id": "activate-power-mode-delete@0.5.3",
+  "_shasum": "90494cba611dae866dfcec93e06fa8c64a1cd4f8",
+  "_resolved": "file:../d-11644-1664-lba25h/package.tgz",
+  "_from": "../d-11644-1664-lba25h/package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [
+      {
+        "name": "lodash.random",
+        "version": "3.1.4",
+        "path": "node_modules/lodash.random/index.js"
+      },
+      {
+        "name": "lodash.throttle",
+        "version": "3.0.4",
+        "path": "node_modules/lodash.throttle/index.js"
+      },
+      {
+        "name": "lodash.debounce",
+        "version": "3.1.1",
+        "path": "node_modules/lodash.throttle/node_modules/lodash.debounce/index.js"
+      },
+      {
+        "name": "lodash._getnative",
+        "version": "3.9.1",
+        "path": "node_modules/lodash.throttle/node_modules/lodash.debounce/node_modules/lodash._getnative/index.js"
+      }
+    ],
+    "extensions": {
+      ".coffee": [
+        "lib/activate-power-mode.coffee",
+        "lib/config-schema.coffee"
+      ],
+      ".js": [
+        "node_modules/lodash.random/index.js",
+        "node_modules/lodash.throttle/index.js",
+        "node_modules/lodash.throttle/node_modules/lodash.debounce/index.js",
+        "node_modules/lodash.throttle/node_modules/lodash.debounce/node_modules/lodash._getnative/index.js"
+      ],
+      ".json": [
+        "node_modules/lodash.random/package.json",
+        "node_modules/lodash.throttle/node_modules/lodash.debounce/node_modules/lodash._getnative/package.json",
+        "node_modules/lodash.throttle/node_modules/lodash.debounce/package.json",
+        "node_modules/lodash.throttle/package.json",
+        "package.json"
+      ]
+    },
+    "folders": [
+      {
+        "paths": [
+          "lib",
+          ""
+        ],
+        "dependencies": {
+          "lodash.random": "^3.0.1",
+          "lodash.throttle": "^3.0.4"
+        }
+      },
+      {
+        "paths": [
+          "node_modules/lodash.throttle"
+        ],
+        "dependencies": {
+          "lodash.debounce": "^3.0.0"
+        }
+      },
+      {
+        "paths": [
+          "node_modules/lodash.throttle/node_modules/lodash.debounce"
+        ],
+        "dependencies": {
+          "lodash._getnative": "^3.0.0"
+        }
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "activate-power-mode-delete",
   "main": "./lib/activate-power-mode",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Activate POWER MODE to write your code in style.",
   "keywords": [],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "activate-power-mode-delete",
   "main": "./lib/activate-power-mode",
   "version": "0.6.0",
-  "description": "Activate POWER MODE to write your code in style.",
+  "description": "Activate POWER MODE to DELETE powerfully. Original package was overwhelming, these effects are on delete only.",
   "keywords": [],
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "lodash.random": "^3.0.1",
     "lodash.throttle": "^3.0.4"
   },
-  "readme": "# activate-power-mode-delete atom package\nA package for Atom to replicate the effects from [codeinthedark/editor](https://github.com/codeinthedark/editor). Available through the Atom package installer (https://atom.io/packages/activate-power-mode-delete). \n\nActivate with <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>O</kbd> or through the command panel with `Activate Power Mode: Toggle`. Use the command again to deactivate. \n\n![activate-power-mode-delete-0 4 0](https://cloud.githubusercontent.com/assets/688415/11615565/10f16456-9c65-11e5-8af4-265f01fc83a0.gif)\n\n**For a list of power mode packages to other editors, check out [codeinthedark/awesome-power-mode](https://github.com/codeinthedark/awesome-power-mode).**\n",
+  "readme": "# activate-power-mode-delete atom package\nA package forked from [activate-power-mode](https://atom.io/packages/activate-power-mode). Original package was overwhelming, these effects are on delete only. Available through the Atom package installer (https://atom.io/packages/activate-power-mode-delete). \n\nActivate with <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>o</kbd> or through the command panel with `Activate Power Mode: Toggle`. Use the command again to deactivate. \n\n![activate-power-mode-delete-0 4 0](https://cloud.githubusercontent.com/assets/688415/11615565/10f16456-9c65-11e5-8af4-265f01fc83a0.gif)\n",
   "readmeFilename": "README.md",
   "bugs": {
     "url": ""


### PR DESCRIPTION
[Enter steps to reproduce:]

1. ...
2. ...

**Atom**: 1.37.0 x64
**Electron**: 2.0.18
**OS**: Mac OS X 10.14.5
**Thrown From**: [activate-power-mode-delete](https://github.com/valmassoi/activate-power-mode-delete) package 0.6.1


### Stack Trace

Uncaught TypeError: atom.views.getView(...).shadowRoot.elementFromPoint is not a function

```
At /Users/chrismcneese/.atom/packages/activate-power-mode-delete/lib/activate-power-mode.coffee:115

TypeError: atom.views.getView(...).shadowRoot.elementFromPoint is not a function
    at Object.getColorAtPosition (/packages/activate-power-mode-delete/lib/activate-power-mode.coffee:115:49)
    at Object.spawnParticles (/packages/activate-power-mode-delete/lib/activate-power-mode.coffee:107:14)
    at /packages/activate-power-mode-delete/node_modules/lodash.debounce/index.js:182:23)
    at Object.onChange (/packages/activate-power-mode-delete/lib/activate-power-mode.coffee:76:10)
    at Function.simpleDispatch (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:1174290)
    at Emitter.emit (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:1175731)
    at TextBuffer.emitDidChangeTextEvent (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:504302)
    at TextBuffer.transact (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:492477)
    at TextEditor.transact (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:24215)
    at HTMLElement.s.(anonymous function) (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:307747)
    at CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:349922)
    at KeymapManager.t.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:1214917)
    at KeymapManager.t.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:1211051)
    at WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:285128)
```

### Commands

```
  3x -8:45.2.0 core:close (input.hidden-input)
  5x -0:57.7.0 core:backspace (input.hidden-input)
     -0:48.4.0 autocomplete-plus:confirm (input.hidden-input)
```

### Non-Core Packages

```
activate-power-mode 2.7.0 
activate-power-mode-delete 0.6.1 
atom-clock 0.1.16 
atom-material-syntax 1.0.8 
atom-material-ui 2.1.3 
busy-signal 2.0.1 
intentions 1.1.5 
linter 2.3.0 
linter-ui-default 1.7.1 
prettier-atom 0.56.6 
wakatime 7.1.1 
```
